### PR TITLE
Better documentation for MessageQueueHandler

### DIFF
--- a/docs/api/queues.rst
+++ b/docs/api/queues.rst
@@ -18,10 +18,13 @@ ZeroMQ
    :members:
    :inherited-members:
 
-Redis
+AMQP Message Queues
 -----
 
-.. autoclass:: RedisHandler
+.. autoclass:: MessageQueueHandler
+    :members:
+
+.. autoclass:: MessageQueueSubscriber
     :members:
 
 MultiProcessing

--- a/logbook/queues.py
+++ b/logbook/queues.py
@@ -127,9 +127,24 @@ class MessageQueueHandler(Handler):
     The queue will be filled with JSON exported log records.  To receive such
     log records from a queue you can use the :class:`MessageQueueSubscriber`.
 
-    Example setup::
+    For an AMQP backend such as RabbitMQ::
+
+        handler = MessageQueueHandler('amqp://guest:guest@localhost//')
+
+    This requires the py-amqp or the librabbitmq client library.
+
+    For Redis (requires redis client library)::
+
+        handler = MessageQueueHandler('redis://localhost:8889/0')
+
+    For MongoDB (requires pymongo)::
 
         handler = MessageQueueHandler('mongodb://localhost:27017/logging')
+
+    Several other backends are also supported.
+    Refer to the `kombu`_ documentation
+
+    .. _kombu: http://kombu.readthedocs.org/en/latest/introduction.html
     """
 
     def __init__(self, uri=None, queue='logging', level=NOTSET,

--- a/logbook/queues.py
+++ b/logbook/queues.py
@@ -148,7 +148,7 @@ class MessageQueueHandler(Handler):
     """
 
     def __init__(self, uri=None, queue='logging', level=NOTSET,
-                 filter=None, bubble=False, context=None):
+                 filter=None, bubble=False):
         Handler.__init__(self, level, filter, bubble)
         try:
             import kombu


### PR DESCRIPTION
I've actually removed docs for RedisHandler as `MessageQueueHandler` already supports it. Included documentation for RabbitMQ, Redis and MongoDB as those 3 seem to be the ones properly supported by `kombu`. (Mysterious footnote regarding the rest of them: http://kombu.readthedocs.org/en/latest/introduction.html#f1 )

Requires proof reading.

Removed an unused parameter as it seemed like no one would miss it.