### PR TITLE
logging compat should keep record format strings.

### DIFF
--- a/logbook/compat.py
+++ b/logbook/compat.py
@@ -118,7 +118,7 @@ class RedirectLoggingHandler(logging.Handler):
         """Converts an old logging record into a logbook log record."""
         record = logbook.LogRecord(old_record.name,
                                    self.convert_level(old_record.levelno),
-                                   old_record.msg, old_record.args,
+                                   old_record.msg.replace('%s', '{}'), old_record.args,
                                    None, old_record.exc_info,
                                    self.find_extra(old_record),
                                    self.find_caller(old_record))

--- a/logbook/compat.py
+++ b/logbook/compat.py
@@ -118,8 +118,8 @@ class RedirectLoggingHandler(logging.Handler):
         """Converts an old logging record into a logbook log record."""
         record = logbook.LogRecord(old_record.name,
                                    self.convert_level(old_record.levelno),
-                                   old_record.getMessage(),
-                                   None, None, old_record.exc_info,
+                                   old_record.msg, old_record.args,
+                                   None, old_record.exc_info,
                                    self.find_extra(old_record),
                                    self.find_caller(old_record))
         record.time = self.convert_time(old_record.created)

--- a/logbook/compat.py
+++ b/logbook/compat.py
@@ -59,6 +59,13 @@ class redirected_logging(object):
     __exit__ = end
 
 
+class LoggingCompatRecord(logbook.LogRecord):
+
+    def _format_message(self, msg, *args, **kwargs):
+        assert not kwargs
+        return msg % tuple(args)
+
+
 class RedirectLoggingHandler(logging.Handler):
     """A handler for the stdlib's logging system that redirects
     transparently to logbook.  This is used by the
@@ -116,9 +123,9 @@ class RedirectLoggingHandler(logging.Handler):
 
     def convert_record(self, old_record):
         """Converts an old logging record into a logbook log record."""
-        record = logbook.LogRecord(old_record.name,
+        record = LoggingCompatRecord(old_record.name,
                                    self.convert_level(old_record.levelno),
-                                   old_record.msg.replace('%s', '{}'), old_record.args,
+                                   old_record.msg, old_record.args,
                                    None, old_record.exc_info,
                                    self.find_extra(old_record),
                                    self.find_caller(old_record))

--- a/tests/test_logging_compat.py
+++ b/tests/test_logging_compat.py
@@ -32,7 +32,7 @@ def test_basic_compat(request, set_root_logger_level):
             with redirected_logging(set_root_logger_level):
                 logger.debug('This is from the old system')
                 logger.info('This is from the old system')
-                logger.warn('This is from the old %s' % 'system')
+                logger.warn('This is from the old %s', 'system')
                 logger.error('This is from the old system')
                 logger.critical('This is from the old system')
         assert ('WARNING: %s: This is from the old system' % name) in captured.getvalue()
@@ -40,7 +40,7 @@ def test_basic_compat(request, set_root_logger_level):
         assert handler.records[0].level == logbook.DEBUG
     else:
         assert handler.records[0].level == logbook.WARNING
-        assert handler.records[0].msg == 'This is from the old %s' % 'system'
+        assert handler.records[0].msg == 'This is from the old {}'
 
 
 def test_redirect_logbook():

--- a/tests/test_logging_compat.py
+++ b/tests/test_logging_compat.py
@@ -32,7 +32,7 @@ def test_basic_compat(request, set_root_logger_level):
             with redirected_logging(set_root_logger_level):
                 logger.debug('This is from the old system')
                 logger.info('This is from the old system')
-                logger.warn('This is from the old system')
+                logger.warn('This is from the old %s' % 'system')
                 logger.error('This is from the old system')
                 logger.critical('This is from the old system')
         assert ('WARNING: %s: This is from the old system' % name) in captured.getvalue()
@@ -40,6 +40,7 @@ def test_basic_compat(request, set_root_logger_level):
         assert handler.records[0].level == logbook.DEBUG
     else:
         assert handler.records[0].level == logbook.WARNING
+        assert handler.records[0].msg == 'This is from the old %s' % 'system'
 
 
 def test_redirect_logbook():

--- a/tests/test_logging_compat.py
+++ b/tests/test_logging_compat.py
@@ -40,7 +40,7 @@ def test_basic_compat(request, set_root_logger_level):
         assert handler.records[0].level == logbook.DEBUG
     else:
         assert handler.records[0].level == logbook.WARNING
-        assert handler.records[0].msg == 'This is from the old {}'
+        assert handler.records[0].msg == 'This is from the old %s'
 
 
 def test_redirect_logbook():


### PR DESCRIPTION
For tools like Sentry to aggregate the same log message together, it is important that the information not be lost what the message was without format strings. The logging compat handler however did exactly that by calling ``record.getMesage()`` and creating a logbook.LogRecord with the final formatted message from logging.

The only thing that ``record.getMessage()`` does besides a ``%`` operation is to force the message to a string if it isn't one. Since logbook has the same behaviour itself, this should be a non-problematic replacement.