### PR TITLE
Fix metaclass not added on Python 3.

### DIFF
--- a/logbook/handlers.py
+++ b/logbook/handlers.py
@@ -22,6 +22,8 @@ import traceback
 from datetime import datetime, timedelta
 from collections import deque
 
+from six import add_metaclass
+
 from logbook.base import CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, \
      NOTSET, level_name_property, _missing, lookup_level, \
      Flags, ContextObject, ContextStackManager
@@ -105,6 +107,7 @@ class _HandlerType(type):
         return type.__new__(cls, name, bases, d)
 
 
+@add_metaclass(_HandlerType)
 class Handler(ContextObject):
     """Handler instances dispatch logging events to specific destinations.
 
@@ -147,8 +150,6 @@ class Handler(ContextObject):
 
     If gevent is enabled, the handler is aliased to `greenletbound`.
     """
-    __metaclass__ = _HandlerType
-
     stack_manager = ContextStackManager()
 
     #: a flag for this handler that can be set to `True` for handlers that

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ def run_setup(with_binary):
         cmdclass=cmdclass,
         features=features,
         install_requires=[
+            'six>=1.4.0',
         ],
         **extra
     )

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -33,10 +33,14 @@ def test_custom_handling(activation_strategy, logger):
                 return False
             return logbook.TestHandler.handle(self, record)
 
+    # Check metaclass (== cls.__class__)
+    assert logbook.Handler.__class__ == logbook.handlers._HandlerType
+
     class MyLogger(logbook.Logger):
         def process_record(self, record):
             logbook.Logger.process_record(self, record)
             record.extra['flag'] = 'testing'
+
     log = MyLogger()
     handler = MyTestHandler()
     with capturing_stderr_context() as captured:


### PR DESCRIPTION
`__metaclass__` does nothing on Python 3, but fails silently. There
was no test that `_HandlerType` was set as the metaclass of `Handler`
so it went unnoticed.