### PR TITLE
TaggingLogger not setting record.extra['tags'] properly

### DIFF
--- a/logbook/more.py
+++ b/logbook/more.py
@@ -12,6 +12,7 @@ import re
 import os
 from collections import defaultdict
 from cgi import parse_qsl
+from functools import partial
 
 from logbook.base import RecordDispatcher, dispatch_record, NOTSET, ERROR, NOTICE
 from logbook.handlers import Handler, StringFormatter, \
@@ -104,8 +105,8 @@ class TaggingLogger(RecordDispatcher):
     def __init__(self, name=None, tags=None):
         RecordDispatcher.__init__(self, name)
         # create a method for each tag named
-        list(setattr(self, tag, lambda msg, *args, **kwargs:
-            self.log(tag, msg, *args, **kwargs)) for tag in (tags or ()))
+        for tag in (tags or ()):
+            setattr(self, tag, partial(self.log, tag))
 
     def log(self, tags, msg, *args, **kwargs):
         if isinstance(tags, string_types):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -78,6 +78,27 @@ def test_tagged(default_handler):
     assert 'cmd message' in stringio
 
 
+def test_tagging_logger(default_handler):
+    from logbook import StderrHandler
+    from logbook.more import TaggingLogger
+    stream = StringIO()
+
+    logger = TaggingLogger('tagged', ['a', 'b'])
+    handler = StderrHandler(format_string="{record.msg}|{record.extra[tags]}")
+
+    with handler:
+        with capturing_stderr_context() as captured:
+            logger.a("a")
+            logger.b("b")
+
+    stderr = captured.getvalue()
+
+    assert "a|['a']" in stderr
+    assert "a|['b']" not in stderr
+    assert "b|['b']" in stderr
+    assert "b|['a']" not in stderr
+
+
 def test_external_application_handler(tmpdir, logger):
     from logbook.more import ExternalApplicationHandler as Handler
     fn = tmpdir.join('tempfile')


### PR DESCRIPTION
According to the docstring for TaggingLogger, "The tags themselves are stored as list named 'tags' in the extra dictionary." However, if you expose the contents of the tags variable via a format string, you find that when using the methods generated in TaggingLogger's __init__, record.extra['tags'] is overwritten with the last tag in the list for all the generated methods.

Thus, this code:
```python
from logbook import StderrHandler
from logbook.more import TaggingLogger

h = StderrHandler(format_string="{record.msg}|{record.extra[tags]}")

l = TaggingLogger('tagged', ['a', 'b'])

with h.applicationbound():
    l.a('a')
    l.b('b')
```
outputs:
```
a|['b']
b|['b']
```

The unit test in test_more.py did not test the generated functions and did not check that the tags entry in the extras dict was properly filled.

This pull request takes care of both issues, by using functools.partial instead of a lambda for generating the functions in TaggingLogger's __init__, and adding a unit test similar to the above.